### PR TITLE
Refactor Projection to not use KeyDependentOperation

### DIFF
--- a/gap/treeautgrp.gd
+++ b/gap/treeautgrp.gd
@@ -174,7 +174,6 @@ DeclareOperation("StabilizerOfVertex", [IsTreeAutomorphismGroup, IsObject]);
 ##  < u, v >
 ##  \endexample
 ##
-KeyDependentOperation("Projection", IsTreeAutomorphismGroup, IsPosInt, ReturnTrue);
 DeclareOperation("Projection", [IsTreeAutomorphismGroup, IsList]);
 DeclareOperation("ProjectionNC", [IsTreeAutomorphismGroup, IsObject]);
 

--- a/gap/treeautgrp.gi
+++ b/gap/treeautgrp.gi
@@ -451,12 +451,18 @@ end);
 
 ###############################################################################
 ##
-#M  ProjectionOp (<G>, <k>)
+#M  Projection(<G>, <k>)
 ##
-InstallMethod(ProjectionOp, "for [IsTreeAutomorphismGroup, IsPosInt]",
+InstallMethod(Projection, "for [IsTreeAutomorphismGroup, IsPosInt]",
               [IsTreeAutomorphismGroup, IsPosInt],
 function(G, k)
-  return Projection(G, [k]);
+  if not IsBound(G!.projections) then
+    G!.projections := [];
+  fi;
+  if not IsBound(G!.projections[k]) then
+    G!.projections[k] := Projection(G, [k]);
+  fi;
+  return G!.projections[k];
 end);
 
 

--- a/tst/tree.tst
+++ b/tst/tree.tst
@@ -1,0 +1,20 @@
+# Grigorchuk group
+gap> G := AutomatonGroup("a=(1,1)(1,2),b=(a,c),c=(a,d),d=(1,b)");
+< a, b, c, d >
+gap> IsActingOnRegularTree(G);
+true
+gap> H:=DerivedSubgroup(G);;
+gap> FixesVertex(H,1);
+true
+gap> Projection(H,1);
+< b, a^-1*c, a^-1*d >
+
+#
+gap> K:=Group(G.3);
+< c >
+gap> Projection(K,1);
+< a >
+gap> Projection(K,2);
+< d >
+gap> Projection(K,[2,1]);
+< 1 >


### PR DESCRIPTION
Doing that causes warnings in all other GAP packages that install
methods for `Projection`.

Since there seem to be no tests or examples or documentation covering
this function, I added a new test to verify it works as before.
